### PR TITLE
Replace unity indicators with wingpanel indicators

### DIFF
--- a/pantheon.set
+++ b/pantheon.set
@@ -9,7 +9,6 @@ elementary-add-icon-theme-git
 elementary-wallpapers-bzr
 pantheon-default-settings-bzr
 dee-bzr
-libunity
 scour
 ido
 footnote-bzr
@@ -23,10 +22,6 @@ switchboard-bzr
 switchboard-plug-online-accounts-bzr
 gsignond-plugin-lastfm-bzr
 geary-plank-bzr
-indicator-datetime
-indicator-session-systemd
-indicator-session
-indicator-sound
 libappindicator
 libgnome-control-center
 libindicate
@@ -66,3 +61,11 @@ switchboard-plug-power-bzr
 switchboard-plug-security-privacy-bzr
 ttf-opensans
 wingpanel-rewrite-x11-bzr
+wingpanel-indicator-ayatana-bzr
+wingpanel-indicator-datetime-bzr
+wingpanel-indicator-network-bzr
+wingpanel-indicator-launcher-bzr
+wingpanel-indicator-notifications-bzr
+wingpanel-indicator-power-bzr
+wingpanel-indicator-session-bzr
+wingpanel-indicator-sound-bzr


### PR DESCRIPTION
I took a stab at updating the current package list.

* The indicator-* packages are not used with the x11-rewrite wingpanel.
* Added the new indicators.
* Removed libunity since I don't think it's required anymore, but I could be wrong.

Note that wingpanel-indicator-launcher-bzr is not in Alcuryd's repo, it is only in AUR.  Also, the ayatana indicator doesn't build for me.